### PR TITLE
Move bigint to string data type

### DIFF
--- a/src/utils/data-types.ts
+++ b/src/utils/data-types.ts
@@ -6,16 +6,19 @@ export type DataType = 'string' | 'number' | 'float' | 'datetime' | 'date'
 const NUMBER = [
   // PrimaryGeneratedColumnType:
   'int', 'int2', 'int4', 'int8', 'integer', 'tinyint', 'smallint',
-  'mediumint', 'bigint', 'dec', 'decimal', 'fixed', 'numeric', 'number',
+  'mediumint', 'dec', 'decimal', 'fixed', 'numeric', 'number',
 
   // WithWidthColumnType:
-  'tinyint', 'smallint', 'mediumint', 'int', 'bigint',
+  'tinyint', 'smallint', 'mediumint', 'int',
 
   // SimpleColumnType:
   'int2', 'integer', 'int4', 'int8', 'int64', 'unsigned big int', 'float4', 'float8',
 ]
 
 const STRING = [
+  // PrimaryGeneratedColumnType
+  'bigint',
+
   // SpatialColumnType:
   'geometry', 'geography',
 


### PR DESCRIPTION
In typeorm, bigint type maps to a string type according to this:

https://typeorm.io/#/entities/column-types-for-postgres

However this may be limited to postgres/mysql and subject to the configuration flag bigNumberStrings:

https://github.com/typeorm/typeorm/blob/master/docs/connection-options.md